### PR TITLE
Add flatbuffers dependencies needed for Fedora

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
          # Ubuntu
          sudo apt install cmake qt6-tools-dev libqt6core5compat6-dev libqt6svg6-dev libpcsclite-dev libssl-dev libdigidocpp-dev libldap2-dev gettext pkg-config
          # Fedora
-         sudo dnf install qt6-qtsvg-devel qt6-qttools-devel qt6-qt5compat-devel pcsc-lite-devel openssl-devel libdigidocpp openldap-devel gettext pkg-config
+         sudo dnf install qt6-qtsvg-devel qt6-qttools-devel qt6-qt5compat-devel pcsc-lite-devel openssl-devel libdigidocpp openldap-devel gettext pkg-config flatbuffers-devel flatbuffers-compiler
 
    * Also runtime dependency opensc-pkcs11 and pcscd is needed
 


### PR DESCRIPTION
Commit [e08c566a7426d04ca6549a73a25a1fe41eb0ab7a](https://github.com/open-eid/DigiDoc4-Client/commit/e08c566a7426d04ca6549a73a25a1fe41eb0ab7a) introduced flatbuffers but it was not reflected in Readme